### PR TITLE
Feature/node 859 valgrind check

### DIFF
--- a/.github/actions/centos7-test/test_entrypoint.sh
+++ b/.github/actions/centos7-test/test_entrypoint.sh
@@ -3,7 +3,7 @@
 NODE_VERSION=$1
 curl -sL https://rpm.nodesource.com/setup_$NODE_VERSION.x | bash -
 
-yum install -y nodejs make gcc-c++
+yum install -y nodejs make gcc-c++ valgrind
 
 npm install --unsafe-perm
-npm run test
+npm run test:valgrind

--- a/package-lock.json
+++ b/package-lock.json
@@ -3989,6 +3989,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4596,6 +4601,14 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "release": "node scripts/make-release.js",
-    "valgrind-test": "valgrind --trace-children=yes --leak-check=full --show-leak-kinds=all mocha --timeout 60000 test",
+    "test:valgrind": "valgrind --xml=yes --xml-file=./valgrind.xml --trace-children=yes --leak-check=full --show-leak-kinds=all mocha --timeout 60000 test && node scripts/parse-valgrind.sh",
     "test": "nyc --reporter=text-summary --reporter=html --reporter=lcov --report-dir=./coverage mocha test"
   },
   "repository": {
@@ -63,5 +63,7 @@
     "prettier": "^1.19.1",
     "yargs-interactive": "^3.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "xml-js": "^1.6.11"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "release": "node scripts/make-release.js",
-    "test:valgrind": "valgrind --xml=yes --xml-file=./valgrind.xml --trace-children=yes --leak-check=full --show-leak-kinds=all mocha --timeout 60000 test && node scripts/parse-valgrind.sh",
+    "test:valgrind": "valgrind --xml=yes --xml-file=./valgrind.xml --trace-children=yes --leak-check=full --show-leak-kinds=all mocha --timeout 60000 test && node scripts/parse-valgrind.js",
     "test": "nyc --reporter=text-summary --reporter=html --reporter=lcov --report-dir=./coverage mocha test"
   },
   "repository": {

--- a/scripts/parse-valgrind.js
+++ b/scripts/parse-valgrind.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const convert = require('xml-js');
+const fs = require('fs');
+
+const xml = fs.readFileSync('./valgrind.xml');
+const targetNames = [];
+JSON.parse(fs.readFileSync('./binding.gyp')).targets.forEach((target) => {
+  targetNames.push(target.target_name);
+});
+const result = JSON.parse(convert.xml2json(xml, { compact: true }));
+const relatedErrors = result.valgrindoutput.error.filter((err) => {
+  let match = false;
+  err.stack.frame.forEach((frame) => {
+    targetNames.forEach((targetName) => {
+      if (frame.obj && frame.obj._text.indexOf(`${targetName}.node`) !== -1) {
+        match = true;
+      }
+    });
+  });
+  return match;
+});
+
+if (relatedErrors.length > 0) {
+  console.log('UNEXPECTED VALGRIND ERRORS');
+  console.log(JSON.stringify(relatedErrors, null, 4));
+  // eslint-disable-next-line no-process-exit
+  process.exit(-1);
+} else {
+  console.log('valgrind output clean');
+}


### PR DESCRIPTION
Run valgrind when running tests on Linux.

Includes a small script for checking if any errors are from the built library files and failing the step if so.  You can see a failed build in the following PR that includes an intentional memory leak - https://github.com/Contrast-Security-Inc/node-fn-inspect/pull/11

The output is a little rough, but I think we can iterate on it later if need be.  I think this accomplishes the goal of adding a gate on leaks or invalid memory accesses in our modules being shipped.