### PR TITLE
fix deadlock

### DIFF
--- a/src/code-events.cc
+++ b/src/code-events.cc
@@ -31,7 +31,14 @@ class FnInspectCodeEventHandler : public CodeEventHandler {
     }
 
     void Handle(CodeEvent *event) {
-      v8::Locker locker(isolate);
+      /*
+       * If Handle() is invoked from a worker thread (i.e. during
+       * garbage collection) we don't have access to the isolate
+       * so just bail
+       */
+      if (v8::Isolate::GetCurrent() != isolate) {
+        return;
+      }
       events.enqueue(event, isolate);
     }
     EventNode *dequeue() {

--- a/src/event-queue.cc
+++ b/src/event-queue.cc
@@ -2,11 +2,22 @@
 #include <iostream>
 #include <string.h>
 
+/*
+ * Implements a simple queue of code events that can be
+ * consumed.
+ *
+ * Thread-Safety: There's no locking on these methods so
+ * they aren't thread safe.  However this should be OK
+ * as the expectation is these methods are only ever called
+ * from the main JS thread and they are blocking, there will
+ * only ever be a single thread calling it as a time.  We
+ * may want to revisit this if we ever want to support
+ * handling events from worker_threads.
+ */
 namespace codeevents {
 
 using v8::String;
 
-// TODO need to v8 locker these methods?
 EventQueue::EventQueue() {
   this->head = NULL;
   this->tail = NULL;


### PR DESCRIPTION
This just drops the events if the current execution context isn't the main thread.  I have a question out to the v8-users group asking if it's safe to access the strings in these contexts - https://groups.google.com/g/v8-users/c/HEKt5_6kdPU - but absent of a response I think it's better to just be safe and we can always revisit.  My guess is that it isn't safe, and the fact that these callbacks could get triggered from worker threads in some contexts wasn't understood, but that's just a guess.

I've tested and can reproduce the deadlock pretty easily on both OSX and Linux.  I ran the following script at the root of this repo w/ the `--prof` flag w/ node 14 `node --prof ./test.js`:

```
'use strict';

const { setCodeEventListener } = require('./index.js');

const express = require('express');
const app = express();
app.get('/', (req, res, next) => {
  res.end('hello\n');
});
app.listen('9999', () => console.log('listening on 9999'));

setCodeEventListener((info) => {
  console.log(info);
});

setInterval(() => console.log(Date.now(), 'not deadlocked yet'), 1000);
```

And then in another terminal I just ran `while true ; do curl localhost:9999 ; done` - without this change I see the process stop logging and curl requests hang after a few seconds.  With this change execution continues.

On Linux you can run `gstack <node_pid>` and when it's deadlocked you'll see stack traces like the following for the threads:

```
Thread 3 (Thread 0x7f48b1ff1700 (LWP 28038)):
#0  0x00007f48b2bae2ad in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f48b2ba7bfd in pthread_mutex_lock () from /lib64/libpthread.so.0
#2  0x0000000000ced223 in v8::Locker::Initialize(v8::Isolate*) ()
#3  0x00007f48b03ea033 in codeevents::FnInspectCodeEventHandler::Handle(v8::CodeEvent*) () from /home/ec2-user/node-fn-inspect/build/Release/codeevents.node
#4  0x0000000000e43705 in v8::internal::ExternalCodeEventListener::CodeMoveEvent(v8::internal::AbstractCode, v8::internal::AbstractCode) ()
#5  0x0000000000d5707a in v8::internal::ProfilingMigrationObserver::Move(v8::internal::AllocationSpace, v8::internal::HeapObject, v8::internal::HeapObject, int) ()
#6  0x0000000000d6d41b in void v8::internal::EvacuateVisitorBase::RawMigrateObject<(v8::internal::EvacuateVisitorBase::MigrationMode)1>(v8::internal::EvacuateVisitorBase*, v8::internal::HeapObject, v8::internal::HeapObject, int, v8::internal::AllocationSpace) ()
#7  0x0000000000d706df in v8::internal::FullEvacuator::RawEvacuatePage(v8::internal::MemoryChunk*, long*) ()
#8  0x0000000000d5d17f in v8::internal::Evacuator::EvacuatePage(v8::internal::MemoryChunk*) ()
#9  0x0000000000d5d67f in v8::internal::PageEvacuationTask::RunInParallel(v8::internal::ItemParallelJob::Task::Runner) ()
#10 0x0000000000d4f8c5 in v8::internal::ItemParallelJob::Task::RunInternal() ()
#11 0x0000000000c6c9eb in non-virtual thunk to v8::internal::CancelableTask::Run() ()
#12 0x0000000000a71405 in node::(anonymous namespace)::PlatformWorkerThread(void*) ()
#13 0x00007f48b2ba540b in start_thread () from /lib64/libpthread.so.0
#14 0x00007f48b28dff9f in clone () from /lib64/libc.so.6

Thread 1 (Thread 0x7f48b3aac780 (LWP 28036)):
#0  0x00007f48b2bad946 in do_futex_wait.constprop () from /lib64/libpthread.so.0
#1  0x00007f48b2bada22 in __new_sem_wait_slow.constprop.0 () from /lib64/libpthread.so.0
#2  0x00000000019d39b8 in v8::base::Semaphore::Wait() ()
#3  0x0000000000d4fd12 in v8::internal::ItemParallelJob::Run() ()
#4  0x0000000000d72ef0 in void v8::internal::MarkCompactCollectorBase::CreateAndExecuteEvacuationTasks<v8::internal::FullEvacuator, v8::internal::MarkCompactCollector>(v8::internal::MarkCompactCollector*, v8::internal::ItemParallelJob*, v8::internal::MigrationObserver*, long) ()
#5  0x0000000000d7378c in v8::internal::MarkCompactCollector::EvacuatePagesInParallel() ()
#6  0x0000000000d73955 in v8::internal::MarkCompactCollector::Evacuate() ()
#7  0x0000000000d85941 in v8::internal::MarkCompactCollector::CollectGarbage() ()
#8  0x0000000000d41c68 in v8::internal::Heap::MarkCompact() ()
#9  0x0000000000d43758 in v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) ()
#10 0x0000000000d44527 in v8::internal::Heap::FinalizeIncrementalMarkingIfComplete(v8::internal::GarbageCollectionReason) ()
#11 0x0000000000d48922 in v8::internal::IncrementalMarkingJob::Task::RunInternal() ()
#12 0x0000000000c6c9eb in non-virtual thunk to v8::internal::CancelableTask::Run() ()
#13 0x0000000000a72824 in node::PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<v8::Task, std::default_delete<v8::Task> >) ()
#14 0x0000000000a74689 in node::PerIsolatePlatformData::FlushForegroundTasksInternal() ()
#15 0x000000000137bae6 in uv.async_io.part () at ../deps/uv/src/unix/async.c:163
#16 0x000000000138e5c5 in uv.io_poll () at ../deps/uv/src/unix/linux-core.c:462
#17 0x000000000137c418 in uv_run (loop=0x446c7c0 <default_loop_struct>, mode=UV_RUN_DEFAULT) at ../deps/uv/src/unix/core.c:385
#18 0x0000000000a44974 in node::NodeMainInstance::Run() ()
#19 0x00000000009d1e15 in node::Start(int, char**) ()
#20 0x00007f48b281406a in __libc_start_main () from /lib64/libc.so.6
#21 0x00000000009694cc in _start ()
```
