### PR TITLE
execSync "npm version"

### DIFF
--- a/scripts/make-release.js
+++ b/scripts/make-release.js
@@ -27,11 +27,11 @@ yargsInteractive()
   })
   .then((releaseType) => {
     // Only bump version in local checkout if publishing artifact is successful
-    cp.exec(`npm version ${releaseType}`);
+    cp.execSync(`npm version ${releaseType}`);
   })
   .catch((err) => {
     console.log('Publishing failed:');
     console.log(err);
+    // eslint-disable-next-line no-process-exit
     process.exit(-1);
   });
-  


### PR DESCRIPTION
`fn-inspect` had no tags at all. it appears that the versions were created manually because if `npm version` had been working, it creates tags too. it's also clear why the `distringuish` process was working; it's almost exactly the same. but `distringuish` executed `npm version` successfully.

the problem here was that `cp.exec` was used to execute `npm version "patch"` and apparently node was terminating before the parent process could execute. i verified with a slightly modified version of `make-release` that just didn't do the first `then` function. there were no errors and there were no tags or commits created.

(`distringuish` uses `cp.exec` too and doesn't have this problem, but changing `cp.exec` to `cp.execSync` fixes the problem here.)