### PR TITLE
Npm version fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ['*']
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20, 22]
+        node: [16, 18, 20, 22.5.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: Node v${{ matrix.node }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
seems like 22.5.0 blows up with npm@9, so trying 22.5.1 (if can be fetched in actions)

also, don't release unless tag has a version format...