### PR TITLE
manually create prebuildify for npx

### DIFF
--- a/.github/workflows/release-no-prebuildify-cross.yml
+++ b/.github/workflows/release-no-prebuildify-cross.yml
@@ -39,6 +39,11 @@ jobs:
       #   run: pip install setuptools
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Make prebuildify available to npx
+        # this might be a bit of a hack. i could install prebuildify without
+        # --ignore-scripts, but that seems like a bad idea if ignoring scripts
+        # is important.
+        run: mkdir -p node_modules/.bin && ln -sr node_modules/prebuildify/bin.js node_modules/.bin/prebuildify
       # build each image inline so the matrix doesn't checkout, install, install each time.
       - name: Build alpine
         run: docker run --rm -v ${{ github.workspace }}:/repo -w /repo ghcr.io/bmacnaughton/alpine


### PR DESCRIPTION
we're running ignore scripts. it seems like that prevents the `node_modules/.bin` directory from being created. so there are no files for `npx` to execute.